### PR TITLE
feat: add collapsible sidebar with restaurant list (#31)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,25 @@
+/* ── Map/Satellite toggle ───────────────────────────────────────────── */
+.map-type-toggle {
+  position: fixed;
+  top: 10px;
+  left: var(--map-toggle-left, 42px);
+  transition: left 0.25s ease;
+  z-index: 1000;
+  display: flex;
+  border-radius: 2px;
+  overflow: hidden;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+  background: #fff;
+}
+
+/* On mobile the sidebar slides up from the bottom, so don't shift the toggle */
+@media (max-width: 640px) {
+  .map-type-toggle {
+    left: 10px !important;
+    transition: none;
+  }
+}
+
 .places-error-banner {
   position: absolute;
   top: 60px;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -310,19 +310,11 @@ function App() {
         onToggle={handleSidebarToggle}
       />
 
-      {/* Map/Satellite toggle — slides right when sidebar opens */}
-      <div style={{
-        position: "fixed",
-        top: "10px",
-        left: sidebarOpen ? "322px" : "42px",
-        transition: "left 0.25s ease",
-        zIndex: 1000,
-        display: "flex",
-        borderRadius: "2px",
-        overflow: "hidden",
-        boxShadow: "0 1px 4px rgba(0,0,0,0.3)",
-        background: "#fff",
-      }}>
+      {/* Map/Satellite toggle — slides right when sidebar opens (desktop only) */}
+      <div
+        className="map-type-toggle"
+        style={{ "--map-toggle-left": sidebarOpen ? "322px" : "42px" }}
+      >
         {["roadmap", "satellite"].map((type) => (
           <button
             key={type}

--- a/src/components/Sidebar.css
+++ b/src/components/Sidebar.css
@@ -37,7 +37,6 @@
   font-size: 22px;
   line-height: 1;
   display: inline-block;
-  transform: rotate(0deg);
   transition: transform 0.25s ease;
 }
 

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -3,50 +3,52 @@ import "./Sidebar.css";
 function Sidebar({ restaurants, onRestaurantSelect, deals, isOpen, onToggle }) {
   return (
     <aside
-      className={`sidebar ${isOpen ? "sidebar--open" : "sidebar--closed"}`}
+      className={`sidebar ${isOpen ? "sidebar--open" : ""}`}
       aria-label="Nearby restaurants"
     >
       <button
         className="sidebar-toggle"
         onClick={onToggle}
         aria-expanded={isOpen}
+        aria-controls="sidebar-panel"
         title={isOpen ? "Collapse sidebar" : "Expand sidebar"}
       >
-        <span className="sidebar-toggle-icon" aria-hidden="true">&#8249;</span>
+        <span className="sidebar-toggle-icon" aria-hidden="true">&#8250;</span>
         {!isOpen && <span className="sidebar-toggle-label">Restaurants</span>}
       </button>
-      <div className="sidebar-content">
+      <div id="sidebar-panel" className="sidebar-content">
         <div className="sidebar-header">
           <h2 className="sidebar-title">Nearby Restaurants</h2>
           <span className="sidebar-count">{restaurants.length}</span>
         </div>
-        <ul className="sidebar-list">
-          {restaurants.map((r) => {
-            const dealCount = deals[r.place_id]?.length ?? 0;
-            return (
-              <li key={r.place_id} className="sidebar-item">
-                <button
-                  className="sidebar-item-btn"
-                  onClick={() => onRestaurantSelect(r)}
-                >
-                  <span className="sidebar-item-name">{r.name}</span>
-                  {r.rating && (
-                    <span className="sidebar-item-rating">★ {r.rating}</span>
-                  )}
-                  {r.vicinity && (
-                    <span className="sidebar-item-address">{r.vicinity}</span>
-                  )}
-                  {dealCount > 0 && (
-                    <span className="sidebar-item-deals-badge">
-                      {dealCount} deal{dealCount > 1 ? "s" : ""}
-                    </span>
-                  )}
-                </button>
-              </li>
-            );
-          })}
-        </ul>
-        {restaurants.length === 0 && (
+        {restaurants.length > 0 ? (
+          <ul className="sidebar-list">
+            {restaurants.map((r) => {
+              const dealCount = deals[r.place_id]?.length ?? 0;
+              return (
+                <li key={r.place_id} className="sidebar-item">
+                  <button
+                    className="sidebar-item-btn"
+                    onClick={() => onRestaurantSelect(r)}
+                  >
+                    <span className="sidebar-item-name">{r.name}</span>
+                    {r.rating && (
+                      <span className="sidebar-item-rating">★ {r.rating}</span>
+                    )}
+                    {r.vicinity && (
+                      <span className="sidebar-item-address">{r.vicinity}</span>
+                    )}
+                    {dealCount > 0 && (
+                      <span className="sidebar-item-deals-badge">
+                        {dealCount} deal{dealCount > 1 ? "s" : ""}
+                      </span>
+                    )}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        ) : (
           <p className="sidebar-empty">No restaurants found nearby.</p>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Adds a collapsible sidebar on the left edge listing all nearby restaurants with name, rating, address, and deal count badge
- Clicking any restaurant pans the map and opens the info modal (reuses existing `handleResultSelect`)
- Custom Map/Satellite toggle replaces the built-in Google Maps control and slides right/left with the sidebar
- Mobile responsive: sidebar moves to the bottom of the screen and slides up on open

## Test plan
- [ ] Toggle button appears on left edge; click opens/closes sidebar smoothly
- [ ] Restaurant list shows all 20 results with correct name, rating, address, deal badges
- [ ] Clicking a restaurant pans the map and opens the info modal
- [ ] Map/Satellite buttons slide right when sidebar opens and back when it closes
- [ ] Resize to <640px — sidebar appears at bottom and slides up on open
- [ ] Restaurant count in sidebar matches "Restaurants found: N" in top-right

🤖 Generated with [Claude Code](https://claude.com/claude-code)