### PR TITLE
feat: filter restaurants by rating

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -81,6 +81,7 @@ function App() {
   const [showProfile, setShowProfile] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [mapType, setMapType] = useState("roadmap");
+  const [minRating, setMinRating] = useState(0);
   const userMarkerRef = useRef(null);
   const { isLoaded, loadError } = useLoadScript({
     googleMapsApiKey: import.meta.env.VITE_GOOGLE_MAPS_API_KEY,
@@ -349,6 +350,11 @@ function App() {
     });
   }, [restaurants, currentPosition]);
 
+  const filteredRestaurants = useMemo(() => {
+    if (minRating === 0) return restaurantsWithDistance;
+    return restaurantsWithDistance.filter(r => r.rating && r.rating >= minRating);
+  }, [restaurantsWithDistance, minRating]);
+
   const onMapLoad = (mapInstance) => {
     setMap(mapInstance);
   };
@@ -404,7 +410,7 @@ function App() {
       />
 
       <Sidebar
-        restaurants={restaurantsWithDistance}
+        restaurants={filteredRestaurants}
         onRestaurantSelect={handleResultSelect}
         deals={deals}
         isOpen={sidebarOpen}
@@ -412,6 +418,8 @@ function App() {
         isFavorite={isFavorite}
         favoriteRestaurants={favoriteRestaurants}
         user={user}
+        minRating={minRating}
+        onMinRatingChange={setMinRating}
       />
 
       {/* Map/Satellite toggle — slides right when sidebar opens */}
@@ -494,7 +502,7 @@ function App() {
       
       {/* Restaurant markers component */}
       <RestaurantMarkers
-        restaurants={restaurantsWithDistance}
+        restaurants={filteredRestaurants}
         selectedRestaurant={selectedRestaurant}
         setSelectedRestaurant={setSelectedRestaurant}
         map={map}

--- a/src/components/Sidebar.css
+++ b/src/components/Sidebar.css
@@ -76,11 +76,13 @@
 /* ── Header ─────────────────────────────────────────────────────────── */
 .sidebar-header {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
   padding: 16px 16px 12px;
   border-bottom: 1px solid #e2e8f0;
   flex-shrink: 0;
+  gap: 8px;
 }
 
 .sidebar-title-group {
@@ -93,7 +95,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-left: 10px;
+  flex-wrap: wrap;
 }
 
 .sidebar-sort-label {
@@ -121,6 +123,15 @@
 .sidebar-deals-btn--active {
   background-color: #003f88;
   color: white;
+}
+
+.sidebar-rating-filter {
+  border: 1px solid #dbe4f0;
+  border-radius: 8px;
+  padding: 6px 8px;
+  font-size: 12px;
+  color: #1e293b;
+  background: #fff;
 }
 
 .sidebar-sort {

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import "./Sidebar.css";
 
-function Sidebar({ restaurants, onRestaurantSelect, deals, isOpen, onToggle, isFavorite, favoriteRestaurants = [], user }) {
+function Sidebar({ restaurants, onRestaurantSelect, deals, isOpen, onToggle, isFavorite, favoriteRestaurants = [], user, minRating = 0, onMinRatingChange }) {
     const [sortBy, setSortBy] = useState("distance");
     const [showDeals, setShowDeals] = useState(true);
     const [activeTab, setActiveTab] = useState("nearby");
@@ -62,6 +62,19 @@ function Sidebar({ restaurants, onRestaurantSelect, deals, isOpen, onToggle, isF
                             >
                                 Deals
                             </button>
+
+                            <select
+                                className="sidebar-rating-filter"
+                                aria-label="Minimum rating"
+                                value={minRating}
+                                onChange={(e) => onMinRatingChange(Number(e.target.value))}
+                            >
+                                <option value={0}>Rating</option>
+                                <option value={3}>3+ ★</option>
+                                <option value={3.5}>3.5+ ★</option>
+                                <option value={4}>4+ ★</option>
+                                <option value={4.5}>4.5+ ★</option>
+                            </select>
 
                             <select
                                 id="sidebar-sort"


### PR DESCRIPTION
## Summary
- Adds a minimum rating dropdown filter (3+, 3.5+, 4+, 4.5+) to the sidebar controls
- Filters both the sidebar restaurant list and map markers in sync
- Restaurants without ratings are hidden when a filter is active; selecting "Rating" (all) restores them
- Fixes sidebar header overflow by allowing controls to wrap on narrow widths

Closes #60

## Test plan
- [ ] Open app and verify the rating dropdown appears in the sidebar next to the Deals button
- [ ] Select "4+ ★" and confirm only restaurants rated 4+ appear in the sidebar and on the map
- [ ] Select "Rating" (all) and confirm all restaurants reappear
- [ ] Verify the restaurant count badge updates with filtered results
- [ ] Test on mobile viewport (< 640px) to ensure controls fit in the bottom drawer

🤖 Generated with [Claude Code](https://claude.com/claude-code)